### PR TITLE
nginxとの連携のためにunicornの設定変更

### DIFF
--- a/config/unicorn.rb
+++ b/config/unicorn.rb
@@ -6,7 +6,7 @@ working_directory app_path
 
 pid "#{app_path}/tmp/pids/unicorn.pid"
 
-listen 3000
+listen "#{app_path}/tmp/sockets/unicorn.sock"
 
 stderr_path "#{app_path}/log/unicorn.stderr.log"
 


### PR DESCRIPTION
## WHAT
nginxとunicornを連携させる
## WHY
デプロイには連携が必要なため