### PR TITLE
ヘッダーの微調整

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -250,8 +250,10 @@ GEM
     websocket-extensions (0.1.4)
     xpath (3.2.0)
       nokogiri (~> 1.8)
+
 PLATFORMS
   ruby
+
 DEPENDENCIES
   bootsnap (>= 1.1.0)
   byebug

--- a/app/assets/stylesheets/modules/header.scss
+++ b/app/assets/stylesheets/modules/header.scss
@@ -42,6 +42,7 @@ body {
     &__input {
       height: 40px;
       width: 95%;
+      padding-left:20px;
       border-radius: 4px;
       background: #f5f5f5;
       border: 1px solid #ccc;
@@ -54,7 +55,7 @@ body {
       float: right;
       font-style: normal;
       background: #f5f5f5;
-      border-radius: 4px;
+      background: rgb(102, 102, 102);
     }
   }
 }
@@ -80,7 +81,7 @@ body {
 }
 
 //いいね！アイコン
-.fa.fa-heart-o.fa-2x{
+.far.fa-heart{
   color: #ccc;
   font-size: 18px;
 }

--- a/app/views/products/_header.html.haml
+++ b/app/views/products/_header.html.haml
@@ -30,7 +30,8 @@
 
           %li.header-nav-right__nice
             = link_to '', class:'header-nav-right__nice__link' do
-              %i.fa.fa-heart-o.fa-2x
+              %i.far.fa-heart
+
               %span.header-nav-right__nice__link__nice　いいね！一覧
 
           %li.header-nav-right__info


### PR DESCRIPTION
# WHY
→headerに微調整する箇所があったので

# WHAT
→フォームの中のplaceholderの位置を正しくした
→いいね一覧の❤️が消えていたので最新版のアイコンに変更
フォーム横の虫眼鏡のbackground-colorを黒っぽい色に変更
