### PR TITLE
%imgをimage_tagに書き換え

### DIFF
--- a/app/views/products/_product_box.html.haml
+++ b/app/views/products/_product_box.html.haml
@@ -1,6 +1,6 @@
 =link_to "#", class: "product-box" do 
   .product-box__top
-    %img{src: "#{asset_path "products/sho.jpg"}",width:"213",height:"220"}
+    = image_tag("#{asset_path "products/sho.jpg"}",width:"213",height:"220")
   .product-box__bottom
     .product-box__bottom__title ゆでたまご
     .product-box__bottom__info

--- a/app/views/products/_slide.html.haml
+++ b/app/views/products/_slide.html.haml
@@ -1,12 +1,12 @@
 .slider
   %figure.slider-campFeature
-    %img{src: "#{asset_path "slider/banner-camp.jpg"}"}/
+    = image_tag ("#{asset_path "slider/banner-camp.jpg"}")
   %figure.slider-advertisingApp
-    %img{src: "#{asset_path "slider/main_bg_pc.jpg"}",class: "slide-advertisingApp__backimage",width:"100%"}/
+    = image_tag ("#{asset_path "slider/main_bg_pc.jpg"}",class: "slide-advertisingApp__backimage",width:"100%")
     .slider-advertisingApp__content
-      %img{src: "#{asset_path "slider/main_content_pc.png"}",class:"slide-advertisingApp__content__smartphone",width:"32%"}/
+      = image_tag ("#{asset_path "slider/main_content_pc.png"}",class:"slide-advertisingApp__content__smartphone",width:"32%")
       %h2.title スマホでかんたん<br>フリマアプリ
       %h3.leadSentence メルカリはスマホカメラからすぐに出品できる<br>購入時も安心な独自システムのアプリです
       .slider-advertisingApp__content__appBottons
-        %img{src:"#{asset_path "slider/app-store.svg"}"}/
-        %img{src:"#{asset_path "slider/google-play.svg"}"}/
+        = image_tag("#{asset_path "slider/app-store.svg"}")
+        = image_tag("#{asset_path "slider/google-play.svg"}")

--- a/app/views/products/_slide.html.haml
+++ b/app/views/products/_slide.html.haml
@@ -1,10 +1,10 @@
 .slider
   %figure.slider-campFeature
-    = image_tag ("#{asset_path "slider/banner-camp.jpg"}")
+    = image_tag("#{asset_path "slider/banner-camp.jpg"}")
   %figure.slider-advertisingApp
-    = image_tag ("#{asset_path "slider/main_bg_pc.jpg"}",class: "slide-advertisingApp__backimage",width:"100%")
+    = image_tag("#{asset_path "slider/main_bg_pc.jpg"}",class: "slide-advertisingApp__backimage",width:"100%")
     .slider-advertisingApp__content
-      = image_tag ("#{asset_path "slider/main_content_pc.png"}",class:"slide-advertisingApp__content__smartphone",width:"32%")
+      = image_tag("#{asset_path "slider/main_content_pc.png"}",class:"slide-advertisingApp__content__smartphone",width:"32%")
       %h2.title スマホでかんたん<br>フリマアプリ
       %h3.leadSentence メルカリはスマホカメラからすぐに出品できる<br>購入時も安心な独自システムのアプリです
       .slider-advertisingApp__content__appBottons

--- a/app/views/shared/_footer.html.haml
+++ b/app/views/shared/_footer.html.haml
@@ -1,18 +1,18 @@
 .app-banner
-  %img{ src: "#{asset_path "footer/background_img.jpg"}"}/
+  = image_tag("#{asset_path "footer/background_img.jpg"}")
   .app-banner__pc
     .app-banner__pc__inner
       %h2 スマホでかんたんフリマアプリ
       %p 今すぐ無料ダウンロード！
       .app-banner__icon
-        %img{ src: "#{asset_path "footer/mercari_icon.png"}"}/
+        = image_tag("#{asset_path "footer/mercari_icon.png"}")
         %ul.app-list
           %li
-            %img{ src: "#{asset_path "footer/app-store.svg"}"}/
+            = image_tag("#{asset_path "footer/app-store.svg"}")
           %li
-            %img{ src: "#{asset_path "footer/google-play.svg"}"}/
+            = image_tag("#{asset_path "footer/google-play.svg"}")
     %figure.phone
-      %img{ src: "#{asset_path "footer/phone_image.png"}"}/
+      = image_tag("#{asset_path "footer/phone_image.png"}")
 
 .global-footer
   %nav.footer-info
@@ -85,6 +85,6 @@
           United States
   .footer-bottom
     .footer-bottom__mercari__icon
-      %img{ src: "#{asset_path "footer/logo-white.svg"}"}/
+      = image_tag("#{asset_path "footer/logo-white.svg"}")
     .footer-copyright
       © 2019 Mercari

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -4,7 +4,7 @@
         %section.content__mypage__icon
             %div
                 %figure
-                    %img{src:"#{asset_path "user/member_photo.png"}"}
+                    = image_tag("#{asset_path "user/member_photo.png"}")
                 .content__mypage__icon__name
                     = link_to "yuki" ,"/users/1" 
                     .content__mypage__icon__name__number
@@ -26,7 +26,7 @@
                     %li#list
                         %a.mypage-item-link{href: ""} 
                             %figure
-                                %img{src:"#{asset_path "user/merucari.logo.jpg"}"}
+                                = image_tag("#{asset_path "user/merucari.logo.jpg"}")
                             .mypage-item-link__body
                                 .mypage-item-link__text 事務局から個別メッセージ「【あと払い】メルペイあと払い手数料に関するお知らせ」
                                 .mypage-item-link__time
@@ -37,7 +37,7 @@
                     %li#list
                         %a.mypage-item-link{:href => ""}
                             %figure
-                                %img{src:"#{asset_path "user/merucari.logo.jpg"}"}
+                                = image_tag("#{asset_path "user/merucari.logo.jpg"}")
                             .mypage-item-link__body
                                 .mypage-item-link__text 【出品はじめかたガイド】安心でかんたんに出品する方法をCHECKしてみよう！
                                 .mypage-item-link__time
@@ -48,7 +48,7 @@
                     %li#list
                         %a.mypage-item-link{href: ""}
                             %figure
-                                %img{src:"#{asset_path "user/merucari.logo.jpg"}"}
+                                = image_tag("#{asset_path "user/merucari.logo.jpg"}")
                             .mypage-item-link__body
                                 .mypage-item-link__text 明日、P999還元お得チケットの有効期限が切れます！タップして詳細を確認しましょう。
                                 .mypage-item-link__time
@@ -58,7 +58,7 @@
                     %li#list
                         %a.mypage-item-link{href: ""}
                             %figure
-                                %img{src:"#{asset_path "user/merucari.logo.jpg"}"}
+                                = image_tag("#{asset_path "user/merucari.logo.jpg"}")
                             .mypage-item-link__body
                                 .mypage-item-link__text 【メルカリ安心への取り組み】商品代金は、取引完了まで事務局が大切にお預かりいたします
                                 .mypage-item-link__time
@@ -69,7 +69,7 @@
                     %li#list
                         %a.mypage-item-link{href: ""}
                             %figure
-                                %img{src:"#{asset_path "user/merucari.logo.jpg"}"}
+                                = image_tag("#{asset_path "user/merucari.logo.jpg"}")
                             .mypage-item-link__body
                                 .mypage-item-link__text 《お買い物応援キャンペーン》1,000円の商品を&quot;実質1円&quot;で購入できます！
                                 .mypage-item-link__time
@@ -83,7 +83,7 @@
             %ul#doinglist.content__mypage__contents
                 %li.content__mypage__contents__doinglist
                     %figure
-                        %img{src:"#{asset_path "user/merucari.gray.png"}"}
+                        = image_tag("#{asset_path "user/merucari.gray.png"}")
                     .content__mypage__contents__doinglist__text
                         現在、やることリストはありません
 
@@ -100,12 +100,12 @@
             %ul#doing.content__mypage__contents
                 %li.content__mypage__contents__doing
                     %figure
-                        %img{src:"#{asset_path "user/merucari.gray.png"}"}
+                        = image_tag("#{asset_path "user/merucari.gray.png"}")
                     .content__mypage__contents__doinglist__text
                         取引中の商品がありません
             %ul#end.content__mypage__contents
                 %li.content__mypage__contents__end
                     %figure
-                        %img{src:"#{asset_path "user/merucari.gray.png"}"}
+                        = image_tag("#{asset_path "user/merucari.gray.png"}")
                     .content__mypage__contents__doinglist__text
                         過去に取引した商品がありません

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -9,9 +9,9 @@
         ユーザー名
   .user-details
     .user-profile
-      %img{ src: "#{asset_path "user_bg.jpg"}"}/
+      = image_tag("#{asset_path "user_bg.jpg"}")
       .user-photo
-        %img{ src:"#{asset_path "member_photo_noimage.png"}"}/ 
+        = image_tag("#{asset_path "member_photo_noimage.png"}") 
         %h2.user-name
           ユーザー名
         .user-score


### PR DESCRIPTION
## 作業内容
_product_box.html.haml、products/_slide.html.haml、users/show.html.haml、users/index.html.haml、_footer.html.hamlの%imgタグでの画像指定をimage_tagに変更した。

## 目的
railsのヘルパーメソッド [image_tag](http://railsdoc.com/references/image_tag)を使うことにより、alt属性が空でもファイル名から自動生成してくれるなどのメリットがあるので。


## 目標期限
7/14

## その他（参考URL、追記したgemなどあれば）
[ image_tag-Railsドキュメント](http://railsdoc.com/references/image_tag)
[【Rails】image_tagの使い方を徹底解説！](https://www.pikawaka.com/rails/image_tag)