### PR TITLE
text_fieldをnumber_fieldに書き換え

### DIFF
--- a/app/assets/stylesheets/products/buy_confirmation.scss
+++ b/app/assets/stylesheets/products/buy_confirmation.scss
@@ -213,3 +213,11 @@
     }
   }
 }
+input[type="number"]::-webkit-outer-spin-button,
+input[type="number"]::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+}
+input[type="number"] {
+  -moz-appearance:textfield;
+}

--- a/app/views/products/buy_confirmation.html.haml
+++ b/app/views/products/buy_confirmation.html.haml
@@ -34,7 +34,7 @@
               %label
                 %input{type: "radio",name: "points",class:"select",id:"part-of-points"}
                 %p.single-row 一部のポイントを使う
-              = f.text_field :point,placeholder: "使うポイントを入力",class: "how_points"
+              = f.number_field :point,placeholder: "使うポイントを入力",class: "how_points"
                 
             
         .top-content__payment

--- a/app/views/users/identification.html.haml
+++ b/app/views/users/identification.html.haml
@@ -23,7 +23,7 @@
           .identification-content__middle__form-box__top
             %label 郵便番号
             %p 任意
-          = f.text_field :zip_code, placeholder: "例) 1234567"
+          = f.number_field :zip_code, placeholder: "例) 1234567"
         .identification-content__middle__form-box
           .identification-content__middle__form-box__top
             %label 都道府県


### PR DESCRIPTION
## 作業内容
購入確認ページのポイント入力フォームと本人情報登録ページの郵便番号入力フォームをtext_fieldからnumber_fieldに書き換え


## 目的
該当箇所はテキスト入力フォームではなく数字入力フォームなので 


## 目標期限
7/18


## その他（参考URL、追記したgemなどあれば）
 [number_field Railsドキュメント](http://railsdoc.com/references/number_field)
[input type="number"で表示される矢印ボタン（スピンボタン）をCSSで消す方法](https://www.debriefing-web.com/entry/input-type-number)

