### PR TITLE
トップページのスライドの崩れを修正

### DIFF
--- a/app/assets/stylesheets/slick/slide.scss
+++ b/app/assets/stylesheets/slick/slide.scss
@@ -1,13 +1,22 @@
 // @media screen and (min-width: 1068px){
   .slider{
     width:100%;
-    .slide-backimage{
+    .slider-campFeature{
+      background-color:#EFEDEB;
+      height:390px;
       width:100%;
+      img{
+        margin:0 auto;
+      }
     }
     .slider-advertisingApp{
-        height:390px;
-        max-height:390px;
+      height:390px;
+      width:100%;
+      max-height:390px;
       display:flex;
+      &__backimage{
+        width:100%;
+      }
       &__content{
         margin:0 auto;
         position:relative;

--- a/app/assets/stylesheets/slick/slide.scss
+++ b/app/assets/stylesheets/slick/slide.scss
@@ -15,7 +15,7 @@
         .slide-advertisingApp__content__smartphone{
           position:relative;
           left:49.25%;
-          height:390px;
+          width:32%;
         }
         .title{
           position: absolute;

--- a/app/assets/stylesheets/slick/slide.scss
+++ b/app/assets/stylesheets/slick/slide.scss
@@ -1,14 +1,13 @@
 // @media screen and (min-width: 1068px){
   .slider{
     width:100%;
+    .slide-backimage{
+      width:100%;
+    }
     .slider-advertisingApp{
         height:390px;
         max-height:390px;
       display:flex;
-      .slider-advertisingApp__backimage{
-        height:390px;
-        max-height:390px;
-      }
       &__content{
         margin:0 auto;
         position:relative;

--- a/app/assets/stylesheets/slick/slide.scss
+++ b/app/assets/stylesheets/slick/slide.scss
@@ -14,52 +14,48 @@
       width:100%;
       max-height:390px;
       display:flex;
+      position:relative;
       &__backimage{
         width:100%;
       }
       &__content{
-        margin:0 auto;
-        position:relative;
-        top:-410px;
+        position:absolute;
+        top:0;
+        width:910px;
+        margin: 0 23%;
+        display:flex;
         .slide-advertisingApp__content__smartphone{
-          position:relative;
-          left:49.25%;
-          width:32%;
+          height:390px;
         }
+        &__right{
+          width:470px;
+          padding:50px 0 30px 50px;
         .title{
-          position: absolute;
-          top:100px;
-          left:20%;
           font-size:60px;
           font-weight:bold;
           line-height:70px;
           z-index:100;
-          top: 40px;
+          display:block;
+          width:700px;
         }
         .leadSentence{
-          position: absolute;
-          top: 200px;
-          left:20%;
           font-size:16px;
           z-index:100;
-          margin:0 auto;
+          margin-top:15px;
           line-height:35px;
         }
         &__appBottons{
-          position: absolute;
-          top:300px;
-          left:280px;
+          margin-top:18px;
           display: flex;
           img{
             width:170px;
-            margin-left:10px;
+            margin-right:10px;
           }
         }
       }
     }
   }
-// }
-
+}
 .prev-arrow{
   position:absolute;
   top:44%;

--- a/app/views/products/_slide.html.haml
+++ b/app/views/products/_slide.html.haml
@@ -1,8 +1,8 @@
 .slider
   %figure.slider-campFeature
-    = image_tag("#{asset_path "slider/banner-camp.jpg"}")
+    = image_tag("#{asset_path "slider/banner-camp.jpg"}",class: "slide-backimage")
   %figure.slider-advertisingApp
-    = image_tag("#{asset_path "slider/main_bg_pc.jpg"}",class: "slide-advertisingApp__backimage",width:"100%")
+    = image_tag("#{asset_path "slider/main_bg_pc.jpg"}",class: "slide-backimage")
     .slider-advertisingApp__content
       = image_tag("#{asset_path "slider/main_content_pc.png"}",class:"slide-advertisingApp__content__smartphone",width:"32%")
       %h2.title スマホでかんたん<br>フリマアプリ

--- a/app/views/products/_slide.html.haml
+++ b/app/views/products/_slide.html.haml
@@ -1,8 +1,8 @@
 .slider
   %figure.slider-campFeature
-    = image_tag("#{asset_path "slider/banner-camp.jpg"}",class: "slide-backimage")
+    = image_tag("#{asset_path "slider/banner-camp.jpg"}")
   %figure.slider-advertisingApp
-    = image_tag("#{asset_path "slider/main_bg_pc.jpg"}",class: "slide-backimage")
+    = image_tag("#{asset_path "slider/main_bg_pc.jpg"}",class: "slider-advertisingApp__backimage")
     .slider-advertisingApp__content
       = image_tag("#{asset_path "slider/main_content_pc.png"}",class:"slide-advertisingApp__content__smartphone")
       %h2.title スマホでかんたん<br>フリマアプリ

--- a/app/views/products/_slide.html.haml
+++ b/app/views/products/_slide.html.haml
@@ -4,7 +4,7 @@
   %figure.slider-advertisingApp
     = image_tag("#{asset_path "slider/main_bg_pc.jpg"}",class: "slide-backimage")
     .slider-advertisingApp__content
-      = image_tag("#{asset_path "slider/main_content_pc.png"}",class:"slide-advertisingApp__content__smartphone",width:"32%")
+      = image_tag("#{asset_path "slider/main_content_pc.png"}",class:"slide-advertisingApp__content__smartphone")
       %h2.title スマホでかんたん<br>フリマアプリ
       %h3.leadSentence メルカリはスマホカメラからすぐに出品できる<br>購入時も安心な独自システムのアプリです
       .slider-advertisingApp__content__appBottons

--- a/app/views/products/_slide.html.haml
+++ b/app/views/products/_slide.html.haml
@@ -4,9 +4,10 @@
   %figure.slider-advertisingApp
     = image_tag("#{asset_path "slider/main_bg_pc.jpg"}",class: "slider-advertisingApp__backimage")
     .slider-advertisingApp__content
+      .slider-advertisingApp__content__right
+        %h2.title スマホでかんたん<br>フリマアプリ
+        %h3.leadSentence メルカリはスマホカメラからすぐに出品できる<br>購入時も安心な独自システムのアプリです
+        .slider-advertisingApp__content__right__appBottons
+          = image_tag("#{asset_path "slider/app-store.svg"}")
+          = image_tag("#{asset_path "slider/google-play.svg"}")
       = image_tag("#{asset_path "slider/main_content_pc.png"}",class:"slide-advertisingApp__content__smartphone")
-      %h2.title スマホでかんたん<br>フリマアプリ
-      %h3.leadSentence メルカリはスマホカメラからすぐに出品できる<br>購入時も安心な独自システムのアプリです
-      .slider-advertisingApp__content__appBottons
-        = image_tag("#{asset_path "slider/app-store.svg"}")
-        = image_tag("#{asset_path "slider/google-play.svg"}")


### PR DESCRIPTION
## 作業内容
外付けモニタでトップページのビューが崩れていたので
_slide.html.hamlとslide.scssを編集して修正

## 目的
13インチ以上のスクリーンにも対応させるため。


## 目標期限
7/20 18:00までにmerge


## その他（参考URL、追記したgemなどあれば）
 [CSSでmarginが効かない原因と対処法](https://techacademy.jp/magazine/19504)

