### PR TITLE
users/edit.html.hamlのrenderで呼び出すファイルのフォルダを変更

### DIFF
--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -1,5 +1,6 @@
 .profile-edit-wrapper
   = render 'shared/header'
+  = render 'shared/breadcrumbs'
   .edit-main
     = render "shared/side_bar"
     %form.edit-content

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -1,5 +1,5 @@
 .profile-edit-wrapper
-  = render 'products/header'
+  = render 'sharedheader'
   .edit-main
     = render "shared/side_bar"
     %form.edit-content
@@ -11,5 +11,5 @@
       .edit-content__bottom
         %textarea.edit-content__bottom__text
         %input.edit-content__bottom__submit{type: "submit",value: "変更する"}/
-  = render 'products/exhibition_button'
-  = render 'products/footer'
+  = render 'sharedexhibition_button'
+  = render 'sharedfooter'

--- a/app/views/users/edit.html.haml
+++ b/app/views/users/edit.html.haml
@@ -1,5 +1,5 @@
 .profile-edit-wrapper
-  = render 'sharedheader'
+  = render 'shared/header'
   .edit-main
     = render "shared/side_bar"
     %form.edit-content
@@ -11,5 +11,5 @@
       .edit-content__bottom
         %textarea.edit-content__bottom__text
         %input.edit-content__bottom__submit{type: "submit",value: "変更する"}/
-  = render 'sharedexhibition_button'
-  = render 'sharedfooter'
+  = render 'shared/exhibition_button'
+  = render 'shared/footer'


### PR DESCRIPTION
## 作業内容
users/edit.html.hamlのrender呼び出しファイルのフォルダをproductsからsharedに変更。(部分テンプレートのフォルダが変更されたため)
_breadcrumbs.html.hamlを呼び出した。


## 目的
MissingTemplateエラーを解消し、ユーザー情報編集ページを表示させるため。


## 目標期限
7/20 18:00までにmerge


## その他（参考URL、追記したgemなどあれば）
特になし