### PR TITLE
linkを有効化、link遷移時にjs発火

### DIFF
--- a/app/assets/javascripts/header.js
+++ b/app/assets/javascripts/header.js
@@ -1,60 +1,62 @@
-$(function(){
+$(document).on("turbolinks:load", function(){
+  $(function(){
 
-  var icon = ".far.fa-heart, .fa.fa-bell, .fa.fa-check, .fa.fa-smile"
+    var icon = ".far.fa-heart, .fa.fa-bell, .fa.fa-check, .fa.fa-smile"
 
-  $(".category__parent").hide();
+    $(".category__parent").hide();
 
-  $(".navbar").on("mouseover", function(){
-    $(this.querySelector("span")).css({"color": "#0099e8"});
-    $(this.querySelector(icon)).css({"color": "#0099e8"});
-  }).on("mouseout", function(){
-    $(this).children().css({"color": ""});
-  })
-  
-  $(".header-nav-left li").hover(function(){
-    $('ul', this).show();
-    $('ul li ul', this).hide();
-  },function(){
-    $('ul', this).hide();
-  })
+    $(".navbar").on("mouseover", function(){
+      $(this.querySelector("span")).css({"color": "#0099e8"});
+      $(this.querySelector(icon)).css({"color": "#0099e8"});
+    }).on("mouseout", function(){
+      $(this).children().css({"color": ""});
+    })
+    
+    $(".header-nav-left li").hover(function(){
+      $('ul', this).show();
+      $('ul li ul', this).hide();
+    },function(){
+      $('ul', this).hide();
+    })
 
-  $(".category__parent li, .header-nav-left__nav2 ul li").on("mouseover", function(){
-    $(this).css({"background-color": "#EA342D"});
-    $(this).children().css({"color": "#fff"});
-  }).on("mouseout", function(){
-    $(this).css({"background-color": ""});
-    $(this).children().css({"color": ""});
-  })
-  
-  $(".category__child li").on("mouseover", function(){
-    $(this).css({"background-color": "#f5f5f5"});
-    $(this).children().css({"color": ""});
-  }).on("mouseout", function(){
-    $(this).css({"background-color": ""});
-  })
-  
-  $("#notification").on("mouseover", function(){
-    $(".notification-box").show();
-  }).on("mouseout", function(){
-    $(".notification-box").hide();
-  })
+    $(".category__parent li, .header-nav-left__nav2 ul li").on("mouseover", function(){
+      $(this).css({"background-color": "#EA342D"});
+      $(this).children().css({"color": "#fff"});
+    }).on("mouseout", function(){
+      $(this).css({"background-color": ""});
+      $(this).children().css({"color": ""});
+    })
+    
+    $(".category__child li").on("mouseover", function(){
+      $(this).css({"background-color": "#f5f5f5"});
+      $(this).children().css({"color": ""});
+    }).on("mouseout", function(){
+      $(this).css({"background-color": ""});
+    })
+    
+    $("#notification").on("mouseover", function(){
+      $(".notification-box").show();
+    }).on("mouseout", function(){
+      $(".notification-box").hide();
+    })
 
-  $(".notification-box li").on("mouseover", function(){
-    $(this).css({"background-color": "#f5f5f5"});
-  }).on("mouseout", function(){
-    $(this).css({"background-color": ""});
-  })
+    $(".notification-box li").on("mouseover", function(){
+      $(this).css({"background-color": "#f5f5f5"});
+    }).on("mouseout", function(){
+      $(this).css({"background-color": ""});
+    })
 
-  $("#mypage").on("mouseover", function(){
-    $(".mypage-box").show();
-  }).on("mouseout", function(){
-    $(".mypage-box").hide();
-  })
+    $("#mypage").on("mouseover", function(){
+      $(".mypage-box").show();
+    }).on("mouseout", function(){
+      $(".mypage-box").hide();
+    })
 
-  $(".mypage-box li").on("mouseover", function(){
-    $(this).css({"background-color": "#f5f5f5"});
-  }).on("mouseout", function(){
-    $(this).css({"background-color": ""});
-  })
+    $(".mypage-box li").on("mouseover", function(){
+      $(this).css({"background-color": "#f5f5f5"});
+    }).on("mouseout", function(){
+      $(this).css({"background-color": ""});
+    })
 
-})
+  })
+}); 

--- a/app/assets/javascripts/slider.js
+++ b/app/assets/javascripts/slider.js
@@ -8,39 +8,39 @@ $(document).on("turbolinks:load", function(){
       dots: true
     });
   });
-}); 
 
 
-$(function(){
-  var slider = "#slider"; 
-  var thumbnailItem = "#thumbnail-list .thumbnail-item"; 
-  
-  $(thumbnailItem).each(function(){
-   var index = $(thumbnailItem).index(this);
-   $(this).attr("data-index",index);
-  });
-  
-  $(slider).on('init',function(slick){
-   var index = $(".slide-item.slick-slide.slick-current").attr("data-slick-index");
-   $(thumbnailItem+'[data-index="'+index+'"]').addClass("thumbnail-current");
-  });
-
-  $(slider).slick({
+  $(function(){
+    var slider = "#slider"; 
+    var thumbnailItem = "#thumbnail-list .thumbnail-item"; 
     
-    arrows: false,
-    fade: true,
-    infinite: false 
-  });
-  
-  $(thumbnailItem).on('mouseover',function(){
-    var index = $(this).attr("data-index");
-    $(slider).slick("slickGoTo",index,false);
-  });
-  
-  $(slider).on('beforeChange',function(event,slick, currentSlide,nextSlide){
     $(thumbnailItem).each(function(){
-      $(this).removeClass("thumbnail-current");
+    var index = $(thumbnailItem).index(this);
+    $(this).attr("data-index",index);
     });
-    $(thumbnailItem+'[data-index="'+nextSlide+'"]').addClass("thumbnail-current");
+    
+    $(slider).on('init',function(slick){
+    var index = $(".slide-item.slick-slide.slick-current").attr("data-slick-index");
+    $(thumbnailItem+'[data-index="'+index+'"]').addClass("thumbnail-current");
+    });
+
+    $(slider).slick({
+      
+      arrows: false,
+      fade: true,
+      infinite: false 
+    });
+    
+    $(thumbnailItem).on('mouseover',function(){
+      var index = $(this).attr("data-index");
+      $(slider).slick("slickGoTo",index,false);
+    });
+    
+    $(slider).on('beforeChange',function(event,slick, currentSlide,nextSlide){
+      $(thumbnailItem).each(function(){
+        $(this).removeClass("thumbnail-current");
+      });
+      $(thumbnailItem+'[data-index="'+nextSlide+'"]').addClass("thumbnail-current");
+    });
   });
-});
+}); 

--- a/app/views/products/_product_box.html.haml
+++ b/app/views/products/_product_box.html.haml
@@ -1,4 +1,4 @@
-=link_to "#", class: "product-box" do 
+=link_to product_path(1), class: "product-box" do 
   .product-box__top
     = image_tag("/products/sho.jpg",width:"213",height:"220")
   .product-box__bottom

--- a/app/views/products/buy_confirmation.html.haml
+++ b/app/views/products/buy_confirmation.html.haml
@@ -1,6 +1,6 @@
 .confirmation-wrapper
   .header
-    = link_to '' , class:'header__link' do
+    = link_to root_path, class:'header__link' do
       = image_tag('/products/logo.svg')
 
   .main
@@ -65,7 +65,7 @@
           = link_to"特定商取引に関する表記","#"
 
       .footer__inner__logo
-        = link_to"特定商取引に関する表記",class:'footer-inner__logo__link' do
+        = link_to root_path,class:'footer-inner__logo__link' do
           = image_tag('/products/logo-gray.svg' ,class:'logo__img')
 
       %p.footer__inner__c-mark  

--- a/app/views/products/new.html.haml
+++ b/app/views/products/new.html.haml
@@ -116,7 +116,7 @@
               に同意したことになります。
 
           =f.button  "出品する" , class:"sell-btn-box__btn" ,type: "submit"
-          = link_to  "もどる","#", {class:'sell-btn-box__link'}
+          = link_to  "もどる",:back, {class:'sell-btn-box__link'}
           
 
   %footer.footer-terms

--- a/app/views/products/new.html.haml
+++ b/app/views/products/new.html.haml
@@ -1,7 +1,7 @@
 .entire
   %header.header-new
     %h1.header-new__logo
-      = link_to '' , class:'container__logo__link' do
+      = link_to root_path, class:'container__logo__link' do
         = image_tag('//www-mercari-jp.akamaized.net/assets/img/common/common/logo.svg?1905591235.jpg')
 
   .main
@@ -132,7 +132,7 @@
           = link_to"特定商取引に関する表記","#"
 
       .footer__inner__logo
-        = link_to"特定商取引に関する表記",class:'footer-inner__logo__link' do
+        = link_to root_path,class:'footer-inner__logo__link' do
           = image_tag('//www-mercari-jp.akamaized.net/assets/img/common/common/logo-gray.svg?270352715.jpg')
 
       %p.footer__inner__c-mark  

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -90,7 +90,7 @@
       %span.productshow__price__shopping-fee
         送料込み
     .productshow__shopping-botton
-      = link_to '購入画面に進む','#'
+      = link_to '購入画面に進む',buy_confirmation_product_path
     .productshow__description
       %p.productshow__description__inner
         人気のコーチ パッチワークシグネチャー×パイソン ショルダーバッグです♪(ᴖ◡ᴖ)♪ 

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -34,7 +34,7 @@
           出品者
         %td
           .productshow__table__name
-            = link_to "yuki" ,"/users" 
+            = link_to "yuki" ,user_path(1) 
           .rate
             .rate__score
               %i.fas.fa-laugh

--- a/app/views/shared/_exhibition_button.html.haml
+++ b/app/views/shared/_exhibition_button.html.haml
@@ -1,3 +1,3 @@
-=link_to "#", class: "displayButton" do 
+=link_to new_product_path, class: "displayButton" do 
   .text 出品
   %i.fas.fa-camera

--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -3,7 +3,7 @@
 
     .header__inner__upper
       .logo
-        = link_to '' , class:'c' do
+        = link_to root_path, class:'c' do
           = image_tag('//www-mercari-jp.akamaized.net/assets/img/common/common/logo.svg?1905591235.jpg' , class:"logo-img")
 
       .search
@@ -419,7 +419,7 @@
               %span.header-nav-right__todo__link__todo やることリスト
 
           %li#mypage.header-nav-right__mypage
-            = link_to '', class:'header-nav-right__mypage__link navbar' do
+            = link_to users_path, class:'header-nav-right__mypage__link navbar' do
               %i.fa.fa-smile
               %span.header-nav-right__mypage__link__mypage マイページ
             .mypage-box

--- a/app/views/shared/_side_bar.html.haml
+++ b/app/views/shared/_side_bar.html.haml
@@ -15,7 +15,7 @@
                     いいね！一覧
                     %i.fa.fa-angle-right
             %li
-                =link_to "#", class: "mypage-nav__lists__item" do 
+                =link_to new_product_path, class: "mypage-nav__lists__item" do 
                     出品する
                     %i.fa.fa-angle-right
             %li

--- a/app/views/shared/_side_bar.html.haml
+++ b/app/views/shared/_side_bar.html.haml
@@ -2,7 +2,7 @@
     %nav.mypage-nav__list
         %ul
             %li.mypage
-                =link_to "#", class: "mypage-nav__lists__item__active" do 
+                =link_to users_path, class: "mypage-nav__lists__item__active" do 
                     マイページ
                     %i.fa.fa-angle-right
         %ul#nav
@@ -71,7 +71,7 @@
             設定
         %ul#nav
             %li 
-                =link_to "#", class: "mypage-nav__setting__list" do 
+                =link_to edit_user_path(1), class: "mypage-nav__setting__list" do 
                     プロフィール
                     %i.fa.fa-angle-right
             %li
@@ -79,7 +79,7 @@
                     発送先・お届け先住所変更
                     %i.fa.fa-angle-right
             %li 
-                =link_to "#", class: "mypage-nav__setting__list" do 
+                =link_to cards_path, class: "mypage-nav__setting__list" do 
                     支払い方法
                     %i.fa.fa-angle-right
             %li 
@@ -87,7 +87,7 @@
                     メール/パスワード
                     %i.fa.fa-angle-right
             %li 
-                =link_to "#", class: "mypage-nav__setting__list" do 
+                =link_to identification_user_path(1), class: "mypage-nav__setting__list" do 
                     本人情報
                     %i.fa.fa-angle-right
             %li

--- a/app/views/users/index.html.haml
+++ b/app/views/users/index.html.haml
@@ -6,7 +6,7 @@
                 %figure
                     = image_tag("#{asset_path "user/member_photo.png"}")
                 .content__mypage__icon__name
-                    = link_to "yuki" ,"/users/1" 
+                    = link_to "yuki" ,user_path(1)
                     .content__mypage__icon__name__number
                         %div
                             評価


### PR DESCRIPTION
## 作業内容
各ビューファイルのlink_toの遷移先をprefixで指定
(引数にidが必要な部分は仮置きで1にしています)

## 目的
仮置きのlinkを正しく遷移するようにするため。


## 目標期限
7/21　午前中にmerge


## その他（参考URL、追記したgemなどあれば）

linkで初回遷移時にイベントが発火するように、
ヘッダー、商品詳細ページのスライド部分を
$(document).on('turbolinks:load', function() { });
});
内にネスト 

もどるボタンのリンクは   **= link_to  "もどる",:back**　とすることで実装できました。
[【簡単】Railsで戻るボタンを作るスニペットコード](https://materializer.co/lab/blog/28)