### PR TITLE
[WIP]商品詳細表示のサーバーサイド実装

### DIFF
--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -34,7 +34,8 @@
           出品者
         %td
           .productshow__table__name
-            = link_to "yuki" ,user_path(1) 
+            = link_to user_path(1) do
+              = @user.nickname
           .rate
             .rate__score
               %i.fas.fa-laugh

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -35,7 +35,7 @@
         %td
           .productshow__table__name
             = link_to user_path(1) do
-              = @user.nickname
+              = @product.user.nickname
           .rate
             .rate__score
               %i.fas.fa-laugh
@@ -78,7 +78,7 @@
       %tr
         %th 配送の方法
         %td
-          = @product.name
+          = @product.shipping_method
       %tr
         %th 配送元地域
         %td 大阪

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -81,7 +81,8 @@
           = @product.shipping_method
       %tr
         %th 配送元地域
-        %td 大阪
+        %td 
+          = @product.prefecture_id
       %tr
         %th 発送日の目安
         %td 

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -1,7 +1,7 @@
 .productshow
   .productshow__main
     .productshow__name 
-      おしゃれなカバン
+      = @product.name
 
     #wrap
       %ul#slider
@@ -64,43 +64,43 @@
         %td コーチ
       %tr
         %th 商品のサイズ
-        %td S
+        %td 
+          = @product.size
       %tr
         %th 商品の状態
-        %td やや傷や汚れあり
+        %td 
+          = @product.state
       %tr
         %th 配送料の負担
-        %td 送料込み（出品者負担）
+        %td 
+          = @product.postage
       %tr
         %th 配送の方法
-        %td ゆうゆうメルカリ便
+        %td
+          = @product.name
       %tr
         %th 配送元地域
         %td 大阪
       %tr
         %th 発送日の目安
-        %td 1~2日で発送
+        %td 
+          = @product.shipping_date
+          日で発送
   
   
     .productshow__price
       %span.productshow__price__yen
-        ¥3,000
+        ¥
+        = @product.price
       %span.productshow__price__tax
         (税込)
       %span.productshow__price__shopping-fee
-        送料込み
+        = @product.postage
     .productshow__shopping-botton
       = link_to '購入画面に進む',buy_confirmation_product_path
     .productshow__description
       %p.productshow__description__inner
-        人気のコーチ パッチワークシグネチャー×パイソン ショルダーバッグです♪(ᴖ◡ᴖ)♪ 
-        斜めがけ用のショルダーバッグで長さ調整可能
-
-        アウトレットファクトリー品ではなく直営店購入品です。
-        ヴィンテージに近いオールドコーチ期のレア品。
-
-        お値引きについては出品時から特価で出しておりますので行っておりません。
-        複数購入時のみご相談いただければ幸いです。
+        = @product.description
     %button.like
       %i.far.fa-heart
       %span


### PR DESCRIPTION
## 作業内容
productsコントローラのshowアクションでDBから取得した値を
products/show.html.hamlで表示


## 目的
仮置きの商品情報を、実際のDBに入っている情報に置き換えるため。


## 目標期限
8/2


## その他（参考URL、追記したgemなどあれば）
ダミーデータはseedsで作成する予定です。