### PR TITLE
shipping_methodカラムを追加

### DIFF
--- a/db/migrate/20190723113715_add_shipping_method_to_products.rb
+++ b/db/migrate/20190723113715_add_shipping_method_to_products.rb
@@ -1,0 +1,5 @@
+class AddShippingMethodToProducts < ActiveRecord::Migration[5.2]
+  def change
+    add_column :products, :shipping_method, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_21_092337) do
+ActiveRecord::Schema.define(version: 2019_07_23_113715) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "prefecture_id"
@@ -51,6 +51,7 @@ ActiveRecord::Schema.define(version: 2019_07_21_092337) do
     t.bigint "category_id"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "shipping_method"
     t.index ["category_id"], name: "index_products_on_category_id"
     t.index ["prefecture_id"], name: "index_products_on_prefecture_id"
     t.index ["user_id"], name: "index_products_on_user_id"


### PR DESCRIPTION
## 作業内容
productsテーブルにadd_methodカラムを追加


## 目的
出品する際に配送方法を選択する欄があったため


## 目標期限
7/23日にmerge


## その他（参考URL、追記したgemなどあれば）
 [Ruby on Railsでテーブルのカラムを追加・削除する方法](https://reasonable-code.com/rails-column/)