### PR TITLE
Cardテーブルにuser_idカラムを追加

### DIFF
--- a/db/migrate/20190725112018_add_user_id_to_card.rb
+++ b/db/migrate/20190725112018_add_user_id_to_card.rb
@@ -1,0 +1,5 @@
+class AddUserIdToCard < ActiveRecord::Migration[5.2]
+  def change
+    add_column :cards, :user_id, :integer
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,8 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_24_105240) do
-
+ActiveRecord::Schema.define(version: 2019_07_25_112018) do
 
   create_table "addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.integer "prefecture_id"
@@ -31,6 +30,7 @@ ActiveRecord::Schema.define(version: 2019_07_24_105240) do
     t.integer "security_cord"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.integer "user_id"
   end
 
   create_table "categories", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|


### PR DESCRIPTION
## 作業内容

Cardテーブルにuser_idカラムを追加

## 目的

ユーザー新規登録ページでCardモデルの情報を登録する際、ユーザーと紐づけるための
user_idカラムが必須であるため。

## コマンド

 rails g migration AddUser_idToCard user_id:integer


