### PR TITLE
[WIP]新規登録　カード情報入力の削除

### DIFF
--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -27,8 +27,7 @@ class Users::RegistrationsController < Devise::RegistrationsController
 
     def user_params
       params.require(:user).permit(:nickname,:firstname,:lastname,:firstname_kana,:lastname_kana,:birthday,:email,:password,
-        address_attributes: [:zip_code,:prefecture_id,:city,:block,:building_number,:phone_number],
-        card_attributes: [:card_number, :expiration_date, :security_cord]
+        address_attributes: [:zip_code,:prefecture_id,:city,:block,:building_number,:phone_number]
         )
     end
 

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -64,25 +64,7 @@
       %br/
       = address_f.telephone_field :phone_number , placeholder:'例）09012345678'
       %br/
-  %div
-    = f.fields_for :card do |card_f|
-      = card_f.label :カード番号
-      %br/
-      = card_f.text_field :card_number, placeholder:'半角数字のみ'
-      %br/
-      = card_f.label :カード番号
-      %br/
-      = card_f.date_select(             |
-        :expiration_date,               |
-        discard_day: true,              |
-        start_year: Date.today.year,    |
-        end_year: (Date.today.year+10), |
-        use_month_numbers: true )       |
-      %br/
-      = card_f.label :セキュリティコード
-      %br/
-      = card_f.text_field :card_number, placeholder:'カード背面4桁もしくは3桁の番号'
-      %br/
+      
   .actions
     = f.submit "次へ進む"
 = render "devise/shared/links"


### PR DESCRIPTION
## 作業内容

新規登録ページのカード情報入力の実装の取り消し


## 理由

payjpの実装に伴い、Cardコントローラー、newアクションを使った
カード新規登録ページを作成し、そこで初めてカード情報を登録する方針に変更したため。

新規登録ページではCardコントローラーを介さずDBにデータが入る状態であるため、
計画通りに実装できるイメージを掴めないから。

 

