### PR TITLE
[WIP]カード一覧ページのlink_toに新規カード情報入力ページをリンク先設定する

### DIFF
--- a/app/views/cards/index.html.haml
+++ b/app/views/cards/index.html.haml
@@ -8,7 +8,7 @@
     .card-list-page__frame__index
       %h3.card-list-page__frame__index__text  クレジットカード一覧
       .card-list-page__frame__index__btn
-        = link_to '' , class:'card-list-page__frame__index__btn__in' do
+        = link_to new_card_path, class:'card-list-page__frame__index__btn__in' do
           %i.fa.fa-credit-card.fa-lg
           %span.card-list-page__frame__index__btn__in__link  クレジットカードを追加する
       .card-list-page__frame__index__bottom

--- a/app/views/cards/new.html.haml
+++ b/app/views/cards/new.html.haml
@@ -16,7 +16,6 @@
             %li.card-new-form__inside__card-num__ul__li
               = image_tag '//www-mercari-jp.akamaized.net/assets/img/card/visa.svg?732810650.jpg' , size:'49x20',alt:"visa"
 
-
             %li.card-new-form__inside__card-num__ul__li
               = image_tag '//www-mercari-jp.akamaized.net/assets/img/card/master-card.svg?732810650.jpg' , size:'49x20',alt:"master"
 
@@ -55,10 +54,8 @@
             
             .card-new__inside__security__cord__question
               %i.fas.fa-question-circle
-
               %span.card-new__inside__security__cord__question__text カード裏面の番号とは?
           
-
           .card-new__inside__security__cord__js
             %p.card-new__inside__security__cord__js__p　カードの裏側を参照ください。
             .card-new__inside__security__cord__js__image


### PR DESCRIPTION
作業内容
→カード一覧ページのlonk_toに新規カード情報入力ページをリンク先設定する
目的
→リンク先が未設定なので修正
目標期限
→本日中
その他（参考URL、追記したgemなどあれば）