### PR TITLE
カード未登録で買い物をしようとするとカード新規登録ページに遷移する処理

### DIFF
--- a/app/controllers/cards_controller.rb
+++ b/app/controllers/cards_controller.rb
@@ -34,10 +34,14 @@ def payjp ##トークンを取得保存、トークンを活用して顧客を�
 end
 
 def pay ##支払いの時にトークンと支払い金額をpayjpに渡す
-product = Product.find(params[:id]).price
-customer_id = current_user.card.customer_id
-Payjp.api_key = ENV['PAYJP_PRIVATE_KEY']
-charge = Payjp::Charge.create(amount: product, customer: customer_id, currency: 'jpy')
+  if current_user.card
+    product = Product.find(params[:id]).price
+    customer_id = current_user.card.customer_id
+    Payjp.api_key = ENV['PAYJP_PRIVATE_KEY']
+    charge = Payjp::Charge.create(amount: product, customer: customer_id, currency: 'jpy')
+  else
+   render :new
+  end
 end
 
 private


### PR DESCRIPTION
作業内容
→cardコントローラー#payに条件分岐を書いて
カードを持っていない場合、カード新規作成に遷移するように処理
目的
→カード未登録の時にクレジットを行うとエラになる為、改善策として
目標期限
→すぐ
その他（参考URL、追記したgemなどあれば）