### PR TITLE
販売手数料、販売利益の表示

### DIFF
--- a/app/assets/javascripts/sales_profit.js
+++ b/app/assets/javascripts/sales_profit.js
@@ -1,0 +1,16 @@
+$(document).on("turbolinks:load", function(){
+  $(function() {
+    $(".sale-price__form-box__first__inside__price__input").on("keyup paste",function(){
+      let input = $(".sale-price__form-box__first__inside__price__input").val()
+      if(input>=300){
+        let fee = Math.floor(input *0.1);
+        $(".sale-price__form-box__second__mark1").text("¥"+fee);
+        let profit = input - fee;
+        $(".sale-price__form-box__third__mark1").text("¥"+profit);
+      }else{
+        $(".sale-price__form-box__second__mark1").text("-");
+        $(".sale-price__form-box__third__mark1").text("-");
+      }
+    })
+  });
+}); 

--- a/app/assets/stylesheets/products/new.scss
+++ b/app/assets/stylesheets/products/new.scss
@@ -444,11 +444,8 @@ body {
         font-size: 14px;
       }
       &__mark1 {
-        width: 14px;
-        height: 3px;
         float: right;
-        position: relative;
-        top: 15px;
+        font-size:14px;
       }
     }
     &__third {
@@ -465,11 +462,8 @@ body {
         font-weight: 600;
       }
       &__mark1 {
-        width: 14px;
-        height: 1px;
         float: right;
-        position: relative;
-        top: 15px;
+        font-size:34px;
       }
     }
   }

--- a/app/views/products/new.html.haml
+++ b/app/views/products/new.html.haml
@@ -142,11 +142,11 @@
 
             .sale-price__form-box__second
               .sale-price__form-box__second__label 販売手数料(10%)
-              .sale-price__form-box__second__mark1
+              .sale-price__form-box__second__mark1 -
 
             .sale-price__form-box__third
               .sale-price__form-box__third__label 販売利益
-              .sale-price__form-box__third__mark1
+              .sale-price__form-box__third__mark1 -
 
 
         .sell-btn-box


### PR DESCRIPTION
## 作業内容
商品出品ページでユーザーが入力した販売価格に対する販売手数料、販売利益の表示


## 目的
ユーザーがリアルタイムで販売手数料、販売利益を確認できるようにするため


## 目標期限
8/25


## その他（参考URL、追記したgemなどあれば）
 [jQueryのtext()によるテキスト操作まとめ！](https://www.sejuku.net/blog/40700)