### PR TITLE
ヘッダーにカテゴリー一覧へのリンクを追加

### DIFF
--- a/app/views/shared/_header.html.haml
+++ b/app/views/shared/_header.html.haml
@@ -17,7 +17,7 @@
       .search-nav-left
         %ul.header-nav-left
           %li#category.header-nav-left__nav1
-            = link_to '', class:'header-nav-left__nav1__link navbar navleft' do
+            = link_to categories_path, class:'header-nav-left__nav1__link navbar navleft' do
               %i.fa.fa-list-ul.fa-1.3x
               %span.header-nav-left__nav1__link__character カテゴリーから探す
             %ul.category__parent


### PR DESCRIPTION
## WHAT
ヘッダーにカテゴリー一覧へのリンクを追加

## WHY
ページ間を連結させるため