### PR TITLE
Update exhibit.html.haml

### DIFF
--- a/app/views/products/exhibit.html.haml
+++ b/app/views/products/exhibit.html.haml
@@ -31,5 +31,4 @@
                   %i.far.fa-comment-alt
                 %span.exhibit-wrapper__tab__list__tag
                   出品中
-              - product.images.each do |image| 
-                = image_tag image
+              = image_tag product.images.first


### PR DESCRIPTION
# WHAT
・ユーザーマイページ（現在出品中の商品のページ）で画像が複数表示されてしまっていたのを一枚だけに変更。

# WHY
・画像が邪魔で商品名が隠れてしまう為